### PR TITLE
add meson build files

### DIFF
--- a/include/meson.build
+++ b/include/meson.build
@@ -1,0 +1,4 @@
+install_headers('pl32-file.h',
+				'pl32-memory.h',
+				'pl32-shell.h',
+				'pl32-term.h')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,25 @@
+project('pl32lib', 'c',
+		version : '4.0.0',
+		license : 'LGPL-2.1-or-later')
+
+inc = include_directories('include')
+
+subdir('include')
+subdir('src')
+
+pkg_mod = import('pkgconfig')
+pkg_mod.generate(libraries : pl32lib,
+				version : '4.0',
+				name : 'pl32lib',
+				filebase : 'pl32',
+				description : 'A library containing all portable routines/algorithms I\'ve ever implemented in any program')
+
+## Tests
+testexe = executable('pl32-test.out', 'pl32-test.c',
+					include_directories : inc,
+					link_with : pl32lib)
+test('Check Version', testexe, args : ['version'])
+test('Show Memory Usage', testexe, args : ['show-memusg'])
+test('Parser', testexe, args : ['parser-test'])
+test('Memory Allocation', testexe, args : ['memory-test'])
+test('File Reading', testexe, args : ['file-test'])

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,8 @@
+pl32lib_sources = ['pl32-file.c',
+				'pl32-memory.c',
+				'pl32-posix.c',
+				'pl32-shell.c']
+pl32lib = both_libraries('pl32',
+						pl32lib_sources,
+						include_directories : inc,
+						install : true)

--- a/src/pl32-shell.c
+++ b/src/pl32-shell.c
@@ -148,7 +148,7 @@ uint8_t plShellVarMgmt(plarray_t* cmdline, bool* cmdlineIsNotCommand, plarray_t*
 	while(i < cmdline->size && strchr(array[i], '$') == NULL)
 		i++;
 
-        if(i < cmdline->size && (strchr(array[i], '$') == array[i] || strchr(array[i], '$') == array[i] + 1)){
+	if(i < cmdline->size && (strchr(array[i], '$') == array[i] || strchr(array[i], '$') == array[i] + 1)){
 		char* workVar = strchr(array[i], '$') + 1;
 		j = 0;
 


### PR DESCRIPTION
selecting source files and headers with a wildcard is [purposefully not supported](https://mesonbuild.com/FAQ.html#why-cant-i-specify-target-files-with-a-wildcard), so everything is explicitly defined like before.
tests are also defined, but don't work as non-interactive pl32-test support needs to be implemented.

also i found some spaces used instead of a tab so i fixed it.